### PR TITLE
Allow cache(clear) when calling reghdfe, old

### DIFF
--- a/src/reghdfe.ado
+++ b/src/reghdfe.ado
@@ -1,10 +1,10 @@
-*! version 5.7.2 29jul2019
+*! version 5.7.3 19oct2019
 
 program reghdfe, eclass
-	* Intercept old+version
-	cap syntax, version old
+	* Intercept old+version and cache(clear) operation
+	cap syntax, old [version CACHE(passthru)]
 	if !c(rc) {
-		reghdfe_old, version
+        	reghdfe_old, `version' `cache'
 		exit
 	}
 


### PR DESCRIPTION
Current version throws an error when calling `reghdfe, old cache(clear)`:

```
. sysuse auto
. reghdfe price mpg , absorb(foreign) cache(save) old
. reghdfe price mpg , absorb(foreign) cache(use) old
. reghdfe , old cache(clear)
option old not allowed
```

This fix allows calling `reghdfe, old cache(clear)` to clear cache when using old version.